### PR TITLE
Fixed parsing little endian implicit files

### DIFF
--- a/src/findItemDelimitationItem.js
+++ b/src/findItemDelimitationItem.js
@@ -1,5 +1,5 @@
 /**
- * Internal helper functions for for parsing DICOM elements
+ * Internal helper functions for parsing DICOM elements
  */
 
 var dicomParser = (function (dicomParser)
@@ -38,7 +38,7 @@ var dicomParser = (function (dicomParser)
                     // but we will just log a warning for now
                     var itemDelimiterLength = byteStream.readUint32(); // the length
                     if(itemDelimiterLength !== 0) {
-                        byteStream.warnings('encountered non zero length following item delimeter at position' + byteStream.position - 4 + " while reading element of undefined length with tag ' + element.tag");
+                        byteStream.warnings('encountered non zero length following item delimiter at position' + byteStream.position - 4 + " while reading element of undefined length with tag ' + element.tag");
                     }
                     element.length = byteStream.position - element.dataOffset;
                     return;

--- a/src/littleEndianByteStream.js
+++ b/src/littleEndianByteStream.js
@@ -1,6 +1,6 @@
 /**
  *
- * Interal helper class to assist with parsing class supports reading from a little endian byte
+ * Internal helper class to assist with parsing class supports reading from a little endian byte
  * stream contained in an Uint18Array.  Example usage:
  *
  *  var byteArray = new Uint8Array(32);

--- a/src/readDicomElementImplicit.js
+++ b/src/readDicomElementImplicit.js
@@ -29,18 +29,19 @@ var dicomParser = (function (dicomParser)
             element.hadUndefinedLength = true;
         }
 
-        // peek ahead at the next tag to see if it looks like a sequence.  This is not 100%
-        // safe because a non sequence item could have data that has these bytes, but this
-        // is how to do it without a data dictionary
-        var nextTag = dicomParser.readTag(byteStream);
-        byteStream.seek(-4);
+        if ((byteStream.position + 4) <= byteStream.byteArray.length) {
+            // peek ahead at the next tag to see if it looks like a sequence.  This is not 100%
+            // safe because a non sequence item could have data that has these bytes, but this
+            // is how to do it without a data dictionary
+            var nextTag = dicomParser.readTag(byteStream);
+            byteStream.seek(-4);
 
-        if(nextTag === 'xfffee000')
-        {
-            // parse the sequence
-            dicomParser.readSequenceItemsImplicit(byteStream, element);
-            element.length = byteStream.byteArray.length - element.dataOffset;
-            return element;
+            if (nextTag === 'xfffee000') {
+                // parse the sequence
+                dicomParser.readSequenceItemsImplicit(byteStream, element);
+                element.length = byteStream.byteArray.length - element.dataOffset;
+                return element;
+            }
         }
 
         // if element is not a sequence and has undefined length, we have to

--- a/src/readEncapsulatedPixelData.js
+++ b/src/readEncapsulatedPixelData.js
@@ -1,5 +1,5 @@
 /**
- * Internal helper functions for for parsing DICOM elements
+ * Internal helper functions for parsing DICOM elements
  */
 
 var dicomParser = (function (dicomParser)

--- a/src/readSequenceElementExplicit.js
+++ b/src/readSequenceElementExplicit.js
@@ -1,5 +1,5 @@
 /**
- * Internal helper functions for for parsing DICOM elements
+ * Internal helper functions for parsing DICOM elements
  */
 
 var dicomParser = (function (dicomParser)
@@ -20,7 +20,7 @@ var dicomParser = (function (dicomParser)
             var element = dicomParser.readDicomElementExplicit(byteStream);
             elements[element.tag] = element;
 
-            // we hit an item delimeter tag, return the current offset to mark
+            // we hit an item delimiter tag, return the current offset to mark
             // the end of this sequence item
             if(element.tag === 'xfffee00d')
             {

--- a/src/readSequenceElementImplicit.js
+++ b/src/readSequenceElementImplicit.js
@@ -1,5 +1,5 @@
 /**
- * Internal helper functions for for parsing DICOM elements
+ * Internal helper functions for parsing DICOM elements
  */
 
 var dicomParser = (function (dicomParser)
@@ -20,7 +20,7 @@ var dicomParser = (function (dicomParser)
             var element = dicomParser.readDicomElementImplicit(byteStream);
             elements[element.tag] = element;
 
-            // we hit an item delimeter tag, return the current offset to mark
+            // we hit an item delimiter tag, return the current offset to mark
             // the end of this sequence item
             if(element.tag === 'xfffee00d')
             {
@@ -28,7 +28,7 @@ var dicomParser = (function (dicomParser)
             }
         }
         // eof encountered - log a warning and return what we have for the element
-        byteStream.warnings.push('eof encountered before finding sequence item delimeter in sequence item of undefined length');
+        byteStream.warnings.push('eof encountered before finding sequence item delimiter in sequence item of undefined length');
         return new dicomParser.DataSet(byteStream.byteArray, elements);
     }
 

--- a/src/readSequenceItem.js
+++ b/src/readSequenceItem.js
@@ -1,5 +1,5 @@
 /**
- * Internal helper functions for for parsing DICOM elements
+ * Internal helper functions for parsing DICOM elements
  */
 
 var dicomParser = (function (dicomParser)

--- a/src/readTag.js
+++ b/src/readTag.js
@@ -1,5 +1,5 @@
 /**
- * Internal helper functions for for parsing DICOM elements
+ * Internal helper functions for parsing DICOM elements
  */
 
 var dicomParser = (function (dicomParser)

--- a/test/index.html
+++ b/test/index.html
@@ -10,6 +10,7 @@
 
     <script src="../src/byteArrayParser.js"></script>
     <script src="../src/dataSet.js"></script>
+    <script src="../src/findItemDelimitationItem.js"></script>
     <script src="../src/littleEndianByteStream.js"></script>
     <script src="../src/parseDicomDataSet.js"></script>
     <script src="../src/readDicomElementImplicit.js"></script>

--- a/test/parseDicomElementTest.js
+++ b/test/parseDicomElementTest.js
@@ -116,4 +116,66 @@
         equal(element.dataOffset, 12,  "dataOffset is not correct");
     });
 
+    module("dicomParser.readDicomElementImplicit");
+
+    test("returns element", function() {
+        // Arrange
+        var byteArray = new Uint8Array(8);
+        byteArray[0] = 0x06;
+        byteArray[1] = 0x30;
+        byteArray[2] = 0xA6;
+        byteArray[3] = 0x00;
+        byteArray[4] = 0x00;
+        byteArray[5] = 0x00;
+        byteArray[6] = 0x00;
+        byteArray[7] = 0x00;
+        var byteStream = new dicomParser.LittleEndianByteStream(byteArray);
+
+        // Act
+        var element = dicomParser.readDicomElementImplicit(byteStream);
+
+        // Assert
+        ok(element, "no element returned");
+    });
+
+    test("truncated element defined length returns", function() {
+        // Arrange
+        var byteArray = new Uint8Array(8);
+        byteArray[0] = 0x06;
+        byteArray[1] = 0x30;
+        byteArray[2] = 0xA6;
+        byteArray[3] = 0x00;
+        byteArray[4] = 0x00;
+        byteArray[5] = 0xFF;
+        byteArray[6] = 0xFF;
+        byteArray[7] = 0xFF;
+        var byteStream = new dicomParser.LittleEndianByteStream(byteArray);
+
+        // Act
+        var element = dicomParser.readDicomElementImplicit(byteStream);
+
+        // Assert
+        ok(element, "no element returned");
+    });
+
+    test("truncated element undefined length returns", function() {
+        // Arrange
+        var byteArray = new Uint8Array(8);
+        byteArray[0] = 0x06;
+        byteArray[1] = 0x30;
+        byteArray[2] = 0xA6;
+        byteArray[3] = 0x00;
+        byteArray[4] = 0xFF;
+        byteArray[5] = 0xFF;
+        byteArray[6] = 0xFF;
+        byteArray[7] = 0xFF;
+        var byteStream = new dicomParser.LittleEndianByteStream(byteArray);
+
+        // Act
+        var element = dicomParser.readDicomElementImplicit(byteStream);
+
+        // Assert
+        ok(element, "no element returned");
+    });
+
 })(dicomParser);


### PR DESCRIPTION
I noticed the parser was throwing an exception on a little endian implicit file I had. This is because it would peek to see if the next tag started a sequence item; if there was no next tag because it was at the end of a file, an exception would be thrown. Now the peek only happens if not at the end of the file, and the parsing continues on successfully.

Also minor spelling tweaks (sorry for being a little OCD).