### PR TITLE
fix the nextFrameOffset

### DIFF
--- a/src/readEncapsulatedPixelData.js
+++ b/src/readEncapsulatedPixelData.js
@@ -25,7 +25,7 @@ var dicomParser = (function (dicomParser)
         // calculate the next frame offset so we know when to stop reading this frame
         var nextFrameOffset = byteStream.byteArray.length;
         if(frame < frameOffsets.length - 1) {
-            nextFrameOffset = frameOffsets[frame+1];
+            nextFrameOffset = baseOffset + frameOffsets[frame+1];
         }
 
         // read all fragments for this frame


### PR DESCRIPTION
when calculating nextFrameOffset keep in mint that the frameOffsets[] point of reference is baseOffset, frameOffsets[0] = 0 , since later we are doing a "byteStream.position < nextFrameOffset" we need to adjust the nextFrameOffset to have the point of reference the begining of byteStream, so nextFrameOffset = baseOffset + frameOffsets[frame+1];

It sued to work for cases when the baseOffset smaller than the frame length, in my case I have videos where baseOffset is greater than frame length so it was never getting into the while loop.