### PR TITLE
updated devDependencies and removed grunt-contrib-watch due to security vulnerabilities in its qs dependency

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -79,13 +79,16 @@ module.exports = function(grunt) {
                     destination: 'docs'
                 }
             }
-        },
+        }
+        /* Commented out due to security vulnerabilities in the qs dependency of grunt-contrib-watch 0.6.1. Comment back in (you'll also need to install grunt-contrib-watch) at your own risk!
+        ,
         watch: {
             scripts: {
                 files: ['src/*.js', 'test/*.js', 'src/util/*.js'],
                 tasks: ['concat:build', 'concat:dist', 'jshint', 'qunit']
             }
         }
+        */
     });
 
     require('load-grunt-tasks')(grunt);

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "main": "dist/dicomParser.js",
   "devDependencies": {
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-concat": "^0.3.0",
-    "grunt-contrib-copy": "0.4.x",
-    "grunt-contrib-jshint": "^0.8.0",
-    "grunt-contrib-qunit": "^0.4.0",
-    "grunt-contrib-uglify": "^0.4.0",
-    "grunt-contrib-watch": "^0.6.1",
+    "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-concat": "^0.5.1",
+    "grunt-contrib-copy": "^0.8.0",
+    "grunt-contrib-jshint": "^0.11.2",
+    "grunt-contrib-qunit": "^0.7.0",
+    "grunt-contrib-uglify": "^0.9.1",
     "grunt-version": "^1.0.0",
-    "load-grunt-tasks": "^0.2.1"
+    "load-grunt-tasks": "^3.2.0"
   }
 }


### PR DESCRIPTION
Fix for #19. Left the watch task commented out in case someone still wants to use it.