### PR TITLE
add support for overriding 'isEncapsulated()'

### DIFF
--- a/src/byteStream.js
+++ b/src/byteStream.js
@@ -26,7 +26,7 @@ var dicomParser = (function (dicomParser)
      * @throws will throw an error if the byteArray parameter is not present or invalid
      * @throws will throw an error if the position parameter is not inside the byte array
      */
-    dicomParser.ByteStream = function(byteArrayParser, byteArray, position) {
+    dicomParser.ByteStream = function(byteArrayParser, byteArray, position, transferSyntax) {
         if(byteArrayParser === undefined)
         {
             throw "dicomParser.ByteStream: missing required parameter 'byteArrayParser'";
@@ -52,6 +52,7 @@ var dicomParser = (function (dicomParser)
         this.byteArray = byteArray;
         this.position = position ? position : 0;
         this.warnings = []; // array of string warnings encountered while parsing
+        this.transferSyntax = transferSyntax;
     };
 
     /**

--- a/src/parseDicom.js
+++ b/src/parseDicom.js
@@ -45,7 +45,7 @@ var dicomParser = (function(dicomParser) {
                 // if an infalter callback is registered, use it
                 if (options && options.inflater) {
                     var fullByteArrayCallback = options.inflater(byteArray, position);
-                    return new dicomParser.ByteStream(dicomParser.littleEndianByteArrayParser, fullByteArrayCallback, 0);
+                    return new dicomParser.ByteStream(dicomParser.littleEndianByteArrayParser, fullByteArrayCallback, 0, transferSyntax);
                 }
                 // if running on node, use the zlib library to inflate
                 // http://stackoverflow.com/questions/4224606/how-to-check-whether-a-script-is-running-under-node-js
@@ -59,7 +59,7 @@ var dicomParser = (function(dicomParser) {
                     var fullByteArrayBuffer = dicomParser.alloc(byteArray, inflatedBuffer.length + position);
                     byteArray.copy(fullByteArrayBuffer, 0, 0, position);
                     inflatedBuffer.copy(fullByteArrayBuffer, position);
-                    return new dicomParser.ByteStream(dicomParser.littleEndianByteArrayParser, fullByteArrayBuffer, 0);
+                    return new dicomParser.ByteStream(dicomParser.littleEndianByteArrayParser, fullByteArrayBuffer, 0, transferSyntax);
                 }
                 // if pako is defined - use it.  This is the web browser path
                 // https://github.com/nodeca/pako
@@ -72,7 +72,7 @@ var dicomParser = (function(dicomParser) {
                     var fullByteArray = dicomParser.alloc(byteArray, inflated.length + position);
                     fullByteArray.set(byteArray.slice(0, position), 0);
                     fullByteArray.set(inflated, position);
-                    return new dicomParser.ByteStream(dicomParser.littleEndianByteArrayParser, fullByteArray, 0);
+                    return new dicomParser.ByteStream(dicomParser.littleEndianByteArrayParser, fullByteArray, 0, transferSyntax);
                 }
                 // throw exception since no inflater is available
                 else {
@@ -81,13 +81,13 @@ var dicomParser = (function(dicomParser) {
             }
             if(transferSyntax === '1.2.840.10008.1.2.2') // explicit big endian
             {
-                return new dicomParser.ByteStream(dicomParser.bigEndianByteArrayParser, byteArray, position);
+                return new dicomParser.ByteStream(dicomParser.bigEndianByteArrayParser, byteArray, position, transferSyntax);
             }
             else
             {
                 // all other transfer syntaxes are little endian; only the pixel encoding differs
                 // make a new stream so the metaheader warnings don't come along for the ride
-                return new dicomParser.ByteStream(dicomParser.littleEndianByteArrayParser, byteArray, position);
+                return new dicomParser.ByteStream(dicomParser.littleEndianByteArrayParser, byteArray, position, transferSyntax);
             }
         }
 
@@ -150,3 +150,4 @@ var dicomParser = (function(dicomParser) {
 
     return dicomParser;
 })(dicomParser);
+

--- a/src/readDicomElementExplicit.js
+++ b/src/readDicomElementExplicit.js
@@ -28,6 +28,10 @@ var dicomParser = (function (dicomParser)
         }
     }
 
+    dicomParser.isEncapsulated = function(element, byteStream) {
+        return element.length === 4294967295;
+    };
+
     dicomParser.readDicomElementExplicit = function(byteStream, warnings, untilTag)
     {
         if(byteStream === undefined)
@@ -72,12 +76,14 @@ var dicomParser = (function (dicomParser)
         }
 
 
-        if(element.length === 4294967295)
-        {
-            if(element.tag === 'x7fe00010') {
+        if(element.tag === 'x7fe00010') {
+            if(dicomParser.isEncapsulated(element, byteStream)) {
+                element.hadUndefinedLength = true;
                 dicomParser.findEndOfEncapsulatedElement(byteStream, element, warnings);
                 return element;
-            }   else if(element.vr === 'UN') {
+            }
+        } else if (element.length === 4294967295) {
+            if(element.vr === 'UN') {
                 dicomParser.findAndSetUNElementLength(byteStream, element);
                 return element;
             } else {


### PR DESCRIPTION
This adds `transferSyntax` to `ByteStream` object, so that it can be used by `isEncapsulated`. The logic in `readDicomElementExplicit` is refactored so that `isEncapsulated` is used for the pixel-data, whereas the normal length criteria is used for `UN` and other element types.